### PR TITLE
Update Main.py

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -20,7 +20,7 @@ def convert_url(url):
     if url.startswith('http://www.'):
         return 'http://' + url[len('http://www.'):]
     if url.startswith('www.'):
-        return 'https://' + url[len('www.'):]
+        return 'https://' + url
     if not url.startswith('https://'):
         return 'https://' + url
     return url

--- a/Main.py
+++ b/Main.py
@@ -14,7 +14,19 @@ ob=Screenshot_Clipping.Screenshot()
 img_dir = './static/img/'
 pdf_dir = './static/pdf/'
 
+def convert_url(url):
+    if url.startswith('https://www.'):
+        return 'https://' + url[len('https://www.'):]
+    if url.startswith('http://www.'):
+        return 'http://' + url[len('http://www.'):]
+    if url.startswith('www.'):
+        return 'https://' + url[len('www.'):]
+    if not url.startswith('https://'):
+        return 'https://' + url
+    return url
+
 def url_check(url):
+	url=convert_url(url)
 	valid = validators.url(url)
 	if valid == True:
 		try:


### PR DESCRIPTION
Added method to convert URL which is not starting with https:// or http:// to it's valid from by adding https:// or http:// before it as validators.url() method in Python validates URL starting with https:// or http:// so if the user does not enter in that format (which is because most users don't write https:// on the browser as the browser handles it automatically) it will automatically convert it in this format. Do merge the PR :)